### PR TITLE
Submodule rename bug fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "report"]
+[submodule "13605769psjwtpfcgxtz"]
 	path = report
 	url = https://git.overleaf.com/13605769psjwtpfcgxtz


### PR DESCRIPTION
Made a mistake when renaming the submodule path. .gitmodules still needs
the original name.